### PR TITLE
Remove READ_PHONE_STATE permission as it is not necessary

### DIFF
--- a/android/src/main/java/flutter/moum/sim_info/SimInfoPlugin.java
+++ b/android/src/main/java/flutter/moum/sim_info/SimInfoPlugin.java
@@ -34,10 +34,10 @@ public class SimInfoPlugin implements MethodCallHandler {
 
   @Override
   public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {
-    if (hasPermission(Manifest.permission.READ_PHONE_STATE)) {
-      result.error("PERMISSION_DENIED", null, null);
-      return;
-    }
+//    if (hasPermission(Manifest.permission.READ_PHONE_STATE)) {
+//      result.error("PERMISSION_DENIED", null, null);
+//      return;
+//    }
     if (!isSimStateReady()) {
       result.error("SIM_STATE_NOT_READY", null, null);
       return;


### PR DESCRIPTION
I checked android code, none of our functions needs READ_PHONE_STATE, why do we need this very sensible permission?

https://developer.android.com/reference/android/telephony/TelephonyManager#getSimCountryIso()
https://developer.android.com/reference/android/telephony/TelephonyManager#getNetworkOperatorName()
https://developer.android.com/reference/android/telephony/TelephonyManager#getSimState()
https://developer.android.com/reference/android/telephony/TelephonyManager#getSimOperator()

Tested on android 9, everything works normally without READ_PHONE_STATE permission 